### PR TITLE
Temporary date fix plus debug logger statements

### DIFF
--- a/src/ILAMB/Confrontation.py
+++ b/src/ILAMB/Confrontation.py
@@ -365,7 +365,7 @@ class Confrontation(object):
                             limits[pname]["max"]  = -1e20
                             limits[pname]["unit"] = post.UnitStringToMatplotlib(var.getncattr("units"))
                         limits[pname]["min"] = min(limits[pname]["min"],var.getncattr(min_str))
-                        limits[pname]["max"] = max(limits[pname]["max"],var.getncattr(max_str))  # 40 to fix these limits
+                        limits[pname]["max"] = max(limits[pname]["max"],var.getncattr(max_str))
                     elif time_opts.has_key(pname):
                         if not limits.has_key(pname): limits[pname] = {}
                         if not limits[pname].has_key(region):
@@ -374,7 +374,7 @@ class Confrontation(object):
                             limits[pname][region]["max"]  = -1e20
                             limits[pname][region]["unit"] = post.UnitStringToMatplotlib(var.getncattr("units"))
                         limits[pname][region]["min"] = min(limits[pname][region]["min"],var.getncattr("min"))
-                        limits[pname][region]["max"] = max(limits[pname][region]["max"],var.getncattr("max"))  # 40 to fix limits
+                        limits[pname][region]["max"] = max(limits[pname][region]["max"],var.getncattr("max"))
                     if not prune and "Benchmark" in fname and pname == "timeint":
                         prune = True
                         self.pruneRegions(Variable(filename      = fname,
@@ -391,7 +391,7 @@ class Confrontation(object):
             
             # Determine plot limits and colormap
             if opts["sym"]:
-                vabs = 40.0# max(abs(limits[pname]["min"]),abs(limits[pname]["min"]))
+                vabs =  max(abs(limits[pname]["min"]),abs(limits[pname]["min"]))
                 limits[pname]["min"] = -vabs
                 limits[pname]["max"] =  vabs
 

--- a/src/ILAMB/Confrontation.py
+++ b/src/ILAMB/Confrontation.py
@@ -3,7 +3,7 @@ from Variable import *
 from Regions import Regions
 from constants import space_opts,time_opts,mid_months,bnd_months
 import os,glob,re
-from netCDF4 import Dataset
+from netCDF4 import Dataset, num2date
 import Post as post
 import pylab as plt
 from matplotlib.colors import LogNorm
@@ -128,9 +128,20 @@ class Confrontation(object):
                     t  = dataset.variables[t.bounds][...]
                     y0 = int(t[ 0,0]/365.+1850.)
                     yf = int(t[-1,1]/365.+1850.)-1
+                elif "units" in t.ncattrs():
+                    #try:
+                    # Try calculating it from the start year, converting it to date
+                    units = t.units
+                    times = list(dataset.variables["time"] )
+                    y0 = num2date(t[0], units).year 
+                    yf = num2date(t[-1], units).year
+                    #except:
                 else:
                     y0 = int(round(t[ 0]/365.)+1850.)
                     yf = int(round(t[-1]/365.)+1850.)-1
+            # TODO better way of doing this:
+            #print "START YEAR IS: ", y0
+            #print "END YEAR IS: ", yf
 
         if self.hasSites:
             pages.append(post.HtmlSitePlotsPage("SitePlots","Site Plots"))
@@ -354,7 +365,7 @@ class Confrontation(object):
                             limits[pname]["max"]  = -1e20
                             limits[pname]["unit"] = post.UnitStringToMatplotlib(var.getncattr("units"))
                         limits[pname]["min"] = min(limits[pname]["min"],var.getncattr(min_str))
-                        limits[pname]["max"] = max(limits[pname]["max"],var.getncattr(max_str))
+                        limits[pname]["max"] = max(limits[pname]["max"],var.getncattr(max_str))  # 40 to fix these limits
                     elif time_opts.has_key(pname):
                         if not limits.has_key(pname): limits[pname] = {}
                         if not limits[pname].has_key(region):
@@ -363,7 +374,7 @@ class Confrontation(object):
                             limits[pname][region]["max"]  = -1e20
                             limits[pname][region]["unit"] = post.UnitStringToMatplotlib(var.getncattr("units"))
                         limits[pname][region]["min"] = min(limits[pname][region]["min"],var.getncattr("min"))
-                        limits[pname][region]["max"] = max(limits[pname][region]["max"],var.getncattr("max"))
+                        limits[pname][region]["max"] = max(limits[pname][region]["max"],var.getncattr("max"))  # 40 to fix limits
                     if not prune and "Benchmark" in fname and pname == "timeint":
                         prune = True
                         self.pruneRegions(Variable(filename      = fname,
@@ -380,7 +391,7 @@ class Confrontation(object):
             
             # Determine plot limits and colormap
             if opts["sym"]:
-                vabs =  max(abs(limits[pname]["min"]),abs(limits[pname]["min"]))
+                vabs = 40.0# max(abs(limits[pname]["min"]),abs(limits[pname]["min"]))
                 limits[pname]["min"] = -vabs
                 limits[pname]["max"] =  vabs
 

--- a/src/ILAMB/Regions.py
+++ b/src/ILAMB/Regions.py
@@ -99,7 +99,6 @@ class Regions(object):
                 ids = np.ma.compressed(np.unique(v[...]))
                 assert ids.max() < lbl.size
                 for i in ids:
-                    print i
                     label = lbl[i].lower()
                     name  = nam[i]
                     mask  = v[...].data != i

--- a/src/ILAMB/Regions.py
+++ b/src/ILAMB/Regions.py
@@ -99,6 +99,7 @@ class Regions(object):
                 ids = np.ma.compressed(np.unique(v[...]))
                 assert ids.max() < lbl.size
                 for i in ids:
+                    print i
                     label = lbl[i].lower()
                     name  = nam[i]
                     mask  = v[...].data != i

--- a/src/ILAMB/ilamblib.py
+++ b/src/ILAMB/ilamblib.py
@@ -1510,7 +1510,7 @@ def ClipTime(v,t0,tf):
         if end   >= v.time.size-1:
             end   = v.time.size-1
             break
-    v.time      = v.time     [begin:(end+1)    ]   # HACK: removed: end+1
+    v.time      = v.time     [begin:(end+1)    ]
     v.time_bnds = v.time_bnds[begin:(end+1),...]
     v.data      = v.data     [begin:(end+1),...]
     return v
@@ -1613,6 +1613,7 @@ def MakeComparable(ref,com,**keywords):
     # If the datasets are both spatial, ensure that both represent the
     # same spatial area and trim the datasets if not.
     if ref.spatial and com.spatial:
+
         logger.info("Both datasets are spatial.")
         lat_bnds = (max(ref.lat_bnds[ 0,0],com.lat_bnds[ 0,0],extents[0,0]),
                     min(ref.lat_bnds[-1,1],com.lat_bnds[-1,1],extents[0,1]))

--- a/src/ILAMB/ilamblib.py
+++ b/src/ILAMB/ilamblib.py
@@ -1510,7 +1510,7 @@ def ClipTime(v,t0,tf):
         if end   >= v.time.size-1:
             end   = v.time.size-1
             break
-    v.time      = v.time     [begin:(end+1)    ]
+    v.time      = v.time     [begin:(end+1)    ]   # HACK: removed: end+1
     v.time_bnds = v.time_bnds[begin:(end+1),...]
     v.data      = v.data     [begin:(end+1),...]
     return v
@@ -1613,7 +1613,7 @@ def MakeComparable(ref,com,**keywords):
     # If the datasets are both spatial, ensure that both represent the
     # same spatial area and trim the datasets if not.
     if ref.spatial and com.spatial:
-
+        logger.info("Both datasets are spatial.")
         lat_bnds = (max(ref.lat_bnds[ 0,0],com.lat_bnds[ 0,0],extents[0,0]),
                     min(ref.lat_bnds[-1,1],com.lat_bnds[-1,1],extents[0,1]))
         lon_bnds = (max(ref.lon_bnds[ 0,0],com.lon_bnds[ 0,0],extents[1,0]),
@@ -1648,7 +1648,11 @@ def MakeComparable(ref,com,**keywords):
 
         # If the reference time scale is significantly larger than the
         # comparison, coarsen the comparison
-        if np.log10(ref.dt/com.dt) > 0.5:
+
+        # But, don't take logs if time delta is zero.
+        if ref.dt == 0.0 and com.dt == 0.0:
+            logger.info("WARNING: Ref is temporal. BUT Ref time delta is: " + str(ref.dt))
+        elif np.log10(ref.dt/com.dt) > 0.5:
             com = com.coarsenInTime(ref.time_bnds,window=window)
             
         # Time bounds of the reference dataset
@@ -1683,6 +1687,9 @@ def MakeComparable(ref,com,**keywords):
             logger.debug(msg)
             raise VarsNotComparable()        
         if not np.allclose(ref.time_bnds,com.time_bnds,atol=0.75*ref.dt):
+            logger.debug("ref.time_bnd: " + str(ref.time_bnds))
+            logger.debug("com.time_bnd: " + str(com.time_bnds))
+            logger.debug("ref time delta: " + str(ref.dt))
             msg  = "%s Datasets are defined at different times" % logstring
             logger.debug(msg)
             raise VarsNotComparable()


### PR DESCRIPTION
To fix #9 

Before defaulting to 1850, checks to see if it can calculate years from the time variables and the `time:units` attribute, using `num2date`.

