### PR TITLE
Link back to results table (WIP)

### DIFF
--- a/src/ILAMB/Post.py
+++ b/src/ILAMB/Post.py
@@ -240,10 +240,11 @@ class HtmlPage(object):
                 else:
                     val  = 0.
             return val        
-        
+        # DV  adding link back to results page... 
         code = """
     <div data-role="page" id="%s">
       <div data-role="header" data-position="fixed" data-tap-toggle="false">
+        <h1><a href="../../../index.html">ILAMB Benchmark Results</a></h1>
         <h1 id="%sHead">%s</h1>""" % (self.name,self.name,self.title)
         if self.pages:
 	    code += """
@@ -603,6 +604,7 @@ class HtmlAllModelsPage(HtmlPage):
         code = """
     <div data-role="page" id="%s">
       <div data-role="header" data-position="fixed" data-tap-toggle="false">
+        
         <h1 id="%sHead">%s</h1>""" % (self.name,self.name,self.title)
         if self.pages:
 	    code += """


### PR DESCRIPTION
To implement a link back to the home page when you are on the results tab. 

Note: Need to think whether we really want this because default behaviour is to open each variable page from the Results Table links as a new tab (`target=_blank` in the html). So would we remove the new tab behaviour too?)

WIP: Not working so far as it seems to break the links on the Results Table page when you click the new header link at the top of each Variable page. (I just added a href inside a new `<h1>` tag...)

See #21 